### PR TITLE
Fix/wdt reset and compiler warnings

### DIFF
--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -90,7 +90,7 @@ void ModbusMaster::beginTransmission(uint16_t u16Address)
 // eliminate this function in favor of using existing MB request functions
 uint8_t ModbusMaster::requestFrom(uint16_t address, uint16_t quantity)
 {
-  uint8_t read;
+  uint8_t read=0;
   // clamp to buffer length
   if (quantity > ku8MaxBufferSize)
   {

--- a/src/ModbusMaster.h
+++ b/src/ModbusMaster.h
@@ -255,7 +255,7 @@ class ModbusMaster
     static const uint8_t ku8MBReadWriteMultipleRegisters = 0x17; ///< Modbus function 0x17 Read Write Multiple Registers
     
     // Modbus timeout [milliseconds]
-    static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
+    static const uint16_t ku16MBResponseTimeout          = 1000; ///< Modbus timeout [milliseconds]
     
     // master function that conducts Modbus transactions
     uint8_t ModbusMasterTransaction(uint8_t u8MBFunction);


### PR DESCRIPTION
In Sming framework variables must be initialized.
If PR 115 @ 4-20ma isn't applied, I get WDT resets on my ESP8266 running Sming. Setting timeout to 1000 solves the problem.